### PR TITLE
Update base URI

### DIFF
--- a/lib/go_to_webinar.rb
+++ b/lib/go_to_webinar.rb
@@ -9,7 +9,7 @@ require "go_to_webinar/sessions"
 
 module GoToWebinar
   class Client
-    
+
     include HTTParty
     format :json
 
@@ -17,29 +17,29 @@ module GoToWebinar
     include GoToWebinar::Registrants
     include GoToWebinar::Attendees
     include GoToWebinar::Sessions
-    
+
     attr_accessor :access_token
     attr_accessor :organizer_key
-    
+
     def initialize(access_token, organizer_key, extra_params = {})
-      
-      # the access token from oauth 
+
+      # the access token from oauth
       @access_token = access_token
       @organizer_key = organizer_key
-      
+
       @default_params = {
-        :base_uri => "https://api.citrixonline.com/G2W/rest/organizers/#{@organizer_key}/",
+        :base_uri => "https://api.getgo.com/G2W/rest/organizers/#{@organizer_key}/",
         :headers => {
           "Content-type" => "application/json",
           "Accept" => "application/json",
-          "Authorization" => "OAuth oauth_token=#{@access_token}" 
+          "Authorization" => "OAuth oauth_token=#{@access_token}"
         }
       }
-      
+
       @default_params = @default_params.merge(extra_params).freeze
       self.class.default_options = self.class.default_options.merge(@default_params).freeze
     end
-    
+
   end
 
 end

--- a/lib/go_to_webinar/attendees.rb
+++ b/lib/go_to_webinar/attendees.rb
@@ -1,25 +1,25 @@
 module GoToWebinar
   module Attendees
-    
+
     def get_attendee(webinar_key, session_key, registrant_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}")
     end
-    
+
     def get_attendee_poll_answers(webinar_key, session_key, registrant_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/polls")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/polls")
     end
-    
+
     def get_attendee_questions(webinar_key, session_key, registrant_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/questions")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/questions")
     end
-    
+
     def get_attendee_survey_answers(webinar_key, session_key, registrant_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/surveys")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/attendees/#{registrant_key}/surveys")
     end
-    
+
     def get_attendees_for_all_webinar_sessions(webinar_key)
-      self.class.get("webinars/#{webinar_key}/attendees")
+      self.class.get("/webinars/#{webinar_key}/attendees")
     end
-    
+
   end
 end

--- a/lib/go_to_webinar/registrants.rb
+++ b/lib/go_to_webinar/registrants.rb
@@ -1,21 +1,21 @@
 module GoToWebinar
   module Registrants
-    
+
     def create_registrant(webinar_key, params)
-      self.class.post("webinars/#{webinar_key}/registrants", :body => params.to_json)
+      self.class.post("/webinars/#{webinar_key}/registrants", :body => params.to_json)
     end
-    
+
     def get_registrant(webinar_key, registrant_key)
-      self.class.get("webinars/#{webinar_key}/registrants/#{registrant_key}")
+      self.class.get("/webinars/#{webinar_key}/registrants/#{registrant_key}")
     end
-    
+
     def get_registrants(webinar_key)
-      self.class.get("webinars/#{webinar_key}/registrants")
+      self.class.get("/webinars/#{webinar_key}/registrants")
     end
-    
+
     def get_registrant_fields(webinar_key)
-      self.class.get("webinars/#{webinar_key}/registrants/fields")
+      self.class.get("/webinars/#{webinar_key}/registrants/fields")
     end
-    
+
   end
 end

--- a/lib/go_to_webinar/sessions.rb
+++ b/lib/go_to_webinar/sessions.rb
@@ -1,37 +1,37 @@
 module GoToWebinar
   module Sessions
-    
+
     def get_organizer_sessions()
-      self.class.get("sessions")
+      self.class.get("/sessions")
     end
-    
+
     def get_session(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}")
     end
-    
+
     def get_session_attendees(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/attendees")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/attendees")
     end
-    
+
     def get_session_performance(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/performance")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/performance")
     end
-    
+
     def get_session_polls(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/polls")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/polls")
     end
-    
+
     def get_session_questions(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/questions")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/questions")
     end
-    
+
     def get_session_surveys(webinar_key, session_key)
-      self.class.get("webinars/#{webinar_key}/sessions/#{session_key}/surveys")
+      self.class.get("/webinars/#{webinar_key}/sessions/#{session_key}/surveys")
     end
-    
+
     def get_webinar_sessions(webinar_key)
-      self.class.get("webinars/#{webinar_key}/sessions")
+      self.class.get("/webinars/#{webinar_key}/sessions")
     end
-    
+
   end
 end

--- a/lib/go_to_webinar/version.rb
+++ b/lib/go_to_webinar/version.rb
@@ -1,3 +1,3 @@
 module GoToWebinar
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/lib/go_to_webinar/webinars.rb
+++ b/lib/go_to_webinar/webinars.rb
@@ -1,25 +1,25 @@
 module GoToWebinar
   module Webinars
-    
+
     def get_historical_webinars(params = {})
-      self.class.get("historicalWebinars", :query => params)
+      self.class.get("/historicalWebinars", :query => params)
     end
-    
+
     def get_upcoming_webinars(params = {})
-      self.class.get("upcomingWebinars", :query => params)
+      self.class.get("/upcomingWebinars", :query => params)
     end
-    
+
     def get_webinar(webinar_key)
-      self.class.get("webinars/#{webinar_key}")
+      self.class.get("/webinars/#{webinar_key}")
     end
-    
+
     def get_webinar_meeting_times(webinar_key)
-      self.class.get("webinars/#{webinar_key}/meetingTimes")
+      self.class.get("/webinars/#{webinar_key}/meetingTimes")
     end
-    
+
     def get_webinars()
-      self.class.get("webinars")
+      self.class.get("/webinars")
     end
-    
+
   end
 end

--- a/test/test_attendees.rb
+++ b/test/test_attendees.rb
@@ -9,7 +9,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
 
     should "generate valid get attendee" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321",:body => '{"registrantKey": "54321"}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321",:body => '{"registrantKey": "54321"}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
@@ -18,7 +18,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid attendee poll answers" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_poll_answers("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -26,7 +26,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendee questions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_questions("12345","12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -34,7 +34,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendee survey answers" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/sessions/12345/attendees/54321/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendee_survey_answers("12345","12345", "54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -42,7 +42,7 @@ class AttendeesTest < Test::Unit::TestCase
     end
     
     should "generate valid get attendees for all webinar sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/12345/webinars/12345/attendees",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/12345/webinars/12345/attendees",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_attendees_for_all_webinar_sessions("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_registrants.rb
+++ b/test/test_registrants.rb
@@ -9,7 +9,7 @@ class RegistrantsTest < Test::Unit::TestCase
     end
 
     should "generate valid create registrant" do
-      FakeWeb.register_uri(:post, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["201", "Created"])
+      FakeWeb.register_uri(:post, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["201", "Created"])
       @r = @c.create_registrant("12345",{"email" => "nathanwfish@something.com"})
       assert FakeWeb.last_request.body.is_a?(String)
       assert_equal('{"email":"nathanwfish@something.com"}', FakeWeb.last_request.body)
@@ -18,7 +18,7 @@ class RegistrantsTest < Test::Unit::TestCase
     end
     
     should "generate valid get registrant" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants/54321", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants/54321", :body => '{"registrantKey":"12345"}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrant("12345","54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
@@ -27,7 +27,7 @@ class RegistrantsTest < Test::Unit::TestCase
     end
     
     should "generate valid get registrants" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '[{"registrantKey":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants", :body => '[{"registrantKey":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrants("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -35,7 +35,7 @@ class RegistrantsTest < Test::Unit::TestCase
     end
 
     should "generate valid get registrant fields" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/12345/registrants/fields", :body => '[{"field":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/12345/registrants/fields", :body => '[{"field":"12345"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_registrant_fields("12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_sessions.rb
+++ b/test/test_sessions.rb
@@ -9,7 +9,7 @@ class SessionsTest < Test::Unit::TestCase
     end
 
     should "generate valid get organizer sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_organizer_sessions()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -17,7 +17,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -25,7 +25,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session attendees" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/attendees",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/attendees",:body => '[{"registrantKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_attendees("54321", "12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -33,7 +33,7 @@ class SessionsTest < Test::Unit::TestCase
     end
 
     should "generate valid get session performance" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/performance",:body => '{"attendance":{"registrantCount":1234}}', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/performance",:body => '{"attendance":{"registrantCount":1234}}', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_performance("54321", "12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Hash)
@@ -42,7 +42,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session polls" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/polls",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_polls("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -50,7 +50,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session questions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/questions",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_questions("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -59,7 +59,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get session surveys" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions/12345/surveys",:body => '[{"question":"something"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_session_surveys("54321","12345")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -67,7 +67,7 @@ class SessionsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinar sessions" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/sessions",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar_sessions("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)

--- a/test/test_webinars.rb
+++ b/test/test_webinars.rb
@@ -9,7 +9,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
 
     should "generate valid get historical webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/historicalWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/historicalWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_historical_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -17,7 +17,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid upcoming webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/upcomingWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/upcomingWebinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_upcoming_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -26,7 +26,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinar" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -34,7 +34,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
 
     should "generate valid get webinar meeting times" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars/54321/meetingTimes",:body => '[{"startTime":"2011-04-26T18:00:00Z"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars/54321/meetingTimes",:body => '[{"startTime":"2011-04-26T18:00:00Z"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinar_meeting_times("54321")
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)
@@ -42,7 +42,7 @@ class WebinarsTest < Test::Unit::TestCase
     end
     
     should "generate valid get webinars" do
-      FakeWeb.register_uri(:get, "https://api.citrixonline.com/G2W/rest/organizers/54321/webinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
+      FakeWeb.register_uri(:get, "https://api.getgo.com/G2W/rest/organizers/54321/webinars",:body => '[{"webinarKey":"54321"}]', :content_type => "application/json", :status => ["200", "OK"])
       @r = @c.get_webinars()
       assert_not_nil @r
       assert @r.parsed_response.is_a?(Array)


### PR DESCRIPTION
Basically copied https://github.com/citrixonline/GoToWebinar-Ruby/pull/4 , which:
- updates the base URI (it's really unfortunate that we didn't received any communication about this and that the responses in the old endpoint return a "Sorry, the page you are looking for is currently unavailable. Please try again later." message) 😢 
- updates the calls to the newer httparty used
- releases 0.0.4